### PR TITLE
Add custom vaultrc for ZSH

### DIFF
--- a/roles/vault/defaults/main.yml
+++ b/roles/vault/defaults/main.yml
@@ -2,3 +2,5 @@
 vault_version: 1.7.0
 
 vault_dir: "{{ ansible_env.HOME }}/.local/lib/vault/{{ vault_version }}"
+
+vault_addr: "https://vault.elhub.cloud:443"

--- a/roles/vault/tasks/vault_env.yml
+++ b/roles/vault/tasks/vault_env.yml
@@ -1,10 +1,17 @@
+- name: Gather facts
+  ansible.builtin.setup:
+
+- name: Determine the shell template
+  set_fact:
+    vaultrc_template: "{{ 'vaultrcZSH.j2' if ansible_env.SHELL.endswith('zsh') else 'vaultrc.j2' }}"
+
 - name: Template .vaultrc
   template:
-    src: "vaultrc.j2"
+    src: "{{ vaultrc_template }}"
     dest: "{{ ansible_env.HOME }}/.vaultrc"
     mode: "u=rw,go=r"
 
-- name: Configure .bashrc
+- name: Configure .bashrc and .zshrc
   lineinfile:
     path: "{{ item }}"
     state: present

--- a/roles/vault/templates/vaultrc.j2
+++ b/roles/vault/templates/vaultrc.j2
@@ -1,4 +1,4 @@
-export VAULT_ADDR="https://vault.elhub.cloud:443"
+export VAULT_ADDR="{{ vault_addr }}"
 
 # Just a little helper to keep vault alive
 vault_autorenew() {

--- a/roles/vault/templates/vaultrcZSH.j2
+++ b/roles/vault/templates/vaultrcZSH.j2
@@ -1,0 +1,1 @@
+export VAULT_ADDR="{{ vault_addr }}"


### PR DESCRIPTION
Summary:
Add a custom vaultrc for zsh that drops the export of functions since zsh does not support that

Testing:
- [ ] Unit Tests
- [ ] Integration Tests


Documentation:
- No updates
