### PR TITLE
Purge GH CLI gpg keyring and source list before installation

### DIFF
--- a/roles/github/tasks/main.yml
+++ b/roles/github/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Clear GitHub CLI GPG keyring
+  file:
+    path: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    state: absent
+- name: Clear GitHub CLI source list
+  file:
+    path: /etc/apt/sources.list.d/github-cli.list
+    state: absent
+
 - name: Install GitHub CLI
   ansible.builtin.shell: >
     (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \


### PR DESCRIPTION
## 📝 Description

The current keyring used to access the github cli has expired, seemingly breaking apt for anyone who currently has it. This change aims to remove the offending files prior to any run of apt, so that it doesn't break during future runs of devxp-linux

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ⚠️ **No tests could be run for this PR.**
