### PR TITLE
feat: homebrew and new strategy for shell rcs

### DIFF
--- a/roles/homebrew/README.md
+++ b/roles/homebrew/README.md
@@ -1,0 +1,7 @@
+# Homebrew
+
+Installs and configures automatic upgrades of [Homebrew](https://brew.sh/).
+
+> The Missing Package Manager for macOS (or Linux)
+
+Adds systemd services and timers for automatic updates and upgrades.

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -66,15 +66,16 @@
     - brew-upgrade.timer
 
 - name: Systemd daemon-reload if services changed
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     daemon_reload: yes
   when: _homebrew_services.changed
   become: true
 
 - name: Enable systemd timers
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     name: "{{ item }}"
     enabled: yes
+    state: started
   become: true
   loop:
     - brew-update.timer

--- a/roles/homebrew/tasks/main.yml
+++ b/roles/homebrew/tasks/main.yml
@@ -1,0 +1,81 @@
+# homebrew tasks file
+---
+- name: Ensure required build tools are installed
+  ansible.builtin.apt:
+    name:
+      - build-essential
+      - procps
+      - curl
+      - file
+      - git
+    state: present
+    update_cache: yes
+  become: true
+
+- name: Download installer script
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/Homebrew/install/master/install.sh
+    dest: /tmp/install_homebrew.sh
+    mode: 0755
+    force: true
+  # We are using force and become since the installation script below will run sudo internally.
+  # Setting become makes ansible run sudo and since sudo is caching credentials for 5 minutes on local connections,
+  # the installation script will not ask for a password.
+  become: true
+  become_user: root
+  when: not '/home/linuxbrew/.linuxbrew' is exists
+
+- name: Run installer script
+  ansible.builtin.shell:
+    cmd: >-
+      /tmp/install_homebrew.sh
+    creates: /home/linuxbrew/.linuxbrew
+  environment:
+    NONINTERACTIVE: '1'
+
+- name: Shell rc file
+  ansible.builtin.copy:
+    content: |
+      # Managed by ansible elhub.wsl.homebrew
+      eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+    dest: "{{ ansible_env.HOME }}/.shrc.d/50-homebrew.sh"
+    mode: 0644
+
+- name: Ensure brew is up to date
+  ansible.builtin.shell:
+    cmd: |
+      set -eu
+      . {{ ansible_env.HOME }}/.shrc.d/50-homebrew.sh
+      brew update
+  register: _homebrew_update
+  changed_when: not 'Already up-to-date.' in _homebrew_update.stdout
+
+- name: Systemd services and timers to update and upgrade
+  ansible.builtin.template:
+    dest: "/usr/lib/systemd/system/{{ item }}"
+    src: "{{ item }}.j2"
+    mode: '0644'
+    owner: root
+    group: root
+  become: true
+  register: _homebrew_services
+  loop:
+    - brew-update.service
+    - brew-update.timer
+    - brew-upgrade.service
+    - brew-upgrade.timer
+
+- name: Systemd daemon-reload if services changed
+  ansible.builtin.systemd:
+    daemon_reload: yes
+  when: _homebrew_services.changed
+  become: true
+
+- name: Enable systemd timers
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    enabled: yes
+  become: true
+  loop:
+    - brew-update.timer
+    - brew-upgrade.timer

--- a/roles/homebrew/templates/brew-update.service.j2
+++ b/roles/homebrew/templates/brew-update.service.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Update Brew binary
+After=local-fs.target
+After=network-online.target
+ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
+
+[Service]
+User={{ ansible_user_id }}
+Type=oneshot
+Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew update"

--- a/roles/homebrew/templates/brew-update.timer.j2
+++ b/roles/homebrew/templates/brew-update.timer.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Timer for updating Brew binary
+Wants=network-online.target
+
+[Timer]
+OnBootSec=10min
+OnUnitInactiveSec=8h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/homebrew/templates/brew-upgrade.service.j2
+++ b/roles/homebrew/templates/brew-upgrade.service.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Upgrade Brew packages
+After=local-fs.target
+After=network-online.target
+ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
+
+[Service]
+User={{ ansible_user_id }}
+Type=oneshot
+Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"

--- a/roles/homebrew/templates/brew-upgrade.timer.j2
+++ b/roles/homebrew/templates/brew-upgrade.timer.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Timer for upgrading Brew packages
+Wants=network-online.target
+
+[Timer]
+OnBootSec=30min
+OnUnitInactiveSec=10h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/shellrc/README.md
+++ b/roles/shellrc/README.md
@@ -1,0 +1,23 @@
+# Shell Run Commands (shrc)
+
+This role sets up a `shrc.d` directory that we use to customize the shell
+environment for users. It allows other roles to add shell configuration files
+without interfering with the regular rc files.
+
+Supported shells:
+
+* bash
+* zsh
+
+We ensure that the parts in the `shrc.d` directory are sourced by the shell when
+it starts by adding a small snippet/loop in `.zshrc` and `.bashrc`.
+
+The different shells will source the files in the `shrc.d` directory based on
+the file extensions.
+
+* `.sh` - sourced by both `bash` and `zsh`
+* `.bash` - sourced by `bash`
+* `.zsh` - sourced by `zsh`
+
+Files are read in lexicographical order, so we generally prefix with a number to
+ensure the correct order.

--- a/roles/shellrc/defaults/main.yml
+++ b/roles/shellrc/defaults/main.yml
@@ -1,0 +1,3 @@
+# shrc defaults file
+---
+shrc_d: "{{ ansible_env.HOME }}/.shrc.d"

--- a/roles/shellrc/tasks/main.yml
+++ b/roles/shellrc/tasks/main.yml
@@ -1,0 +1,33 @@
+# shrc tasks file
+---
+- name: Create shrc.d directory
+  ansible.builtin.file:
+    path: "{{ shrc_d }}"
+    state: directory
+    mode: '0755'
+
+- name: Ensure .bashrc sources shrc.d files
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.bashrc"
+    marker: "# {mark} elhub.wsl.shellrc"
+    create: true
+    mode: '0644'
+    block: |
+      for file in {{ shrc_d }}/*sh; do
+        if [[ -r "$file" ]] && [[ "$file" =~ \.(sh|bash)$ ]]; then
+          source "$file"
+        fi
+      done
+
+- name: Ensure .zshrc sources shrc.d files
+  ansible.builtin.blockinfile:
+    path: "{{ ansible_env.HOME }}/.zshrc"
+    marker: "# {mark} elhub.wsl.shellrc"
+    create: true
+    mode: '0644'
+    block: |
+      for file in {{ shrc_d }}/*sh; do
+        if [[ -r "$file" ]] && [[ "$file" =~ \.(sh|zsh)$ ]]; then
+          source "$file"
+        fi
+      done


### PR DESCRIPTION
This PR adds a fairly standard installation of homebrew, but adds our own flavor: systemd units for update/upgrade.

> [!IMPORTANT]
> This is the kind of thing that takes some time to test, so currently just opening up for feedback.
> There is no harm in merging tho 😉

I'm also suggesting a strategy for handling non-intrusive and multi-shell shell rc/configs. Please see shellrc/README.md