### PR TITLE
feat: Add maven install role

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,78 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+# editorconfig.org
+
+# This file is the top-most EditorConfig file
+root = true
+
+# All Files
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Git
+[.gitmodules]
+indent_style = tab
+
+# Go
+[{go.mod,go.sum,*.go}]
+indent_style = tab
+max_line_length = 160
+
+# Java, Scala, Rust
+[*.{java,scala,rs}]
+max_line_length = 160
+
+# JSON
+[*.json]
+indent_size = 2
+
+# Kotlin
+[*.{kt,kts}]
+max_line_length = 160
+ij_continuation_indent_size = 4
+
+# Makefile
+[{Makefile,**.mk}]
+# Use tabs for indentation (Makefiles require tabs)
+indent_style = tab
+max_line_length = 160
+
+# Markdown
+[*.md]
+max_line_length = 160
+
+# PlantUML
+[*.{puml,plantuml}]
+indent_size = 2
+max_line_length = 160
+
+# Python
+[{*.py, *.pyi}]
+max_line_length = 160
+
+# Shell
+[*.sh]
+indent_size = 2
+max_line_length = 160
+
+# SQL
+[*.{sql}]
+indent_size = 2
+
+# TOML
+[*.toml]
+indent_size = 2
+max_line_length = 160
+
+# YAML
+[*.{yml,yaml}]
+indent_size = 2
+max_line_length = 160
+
+# XML
+[*.{xml}]
+indent_size = 2
+max_line_length = 160

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>elhub/devxp-renovate"]
+  "extends": ["github>elhub/devxp-renovate"],
+  "customManagers": [
+    {
+      "description": "Detects and updates the hardcoded Maven version in main.yml. Maven via sdkman uses a fixed version for controlled updates",
+      "customType": "regex",
+      "fileMatch": [
+        "main\\.ya?ml"
+      ],
+      "matchStrings": [
+        "sdk install (?<depName>maven) (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "org.apache.maven:apache-maven",
+      "datasourceTemplate": "maven",
+      "versioningTemplate": "maven"
+    }
+  ]
 }

--- a/roles/maven/README.md
+++ b/roles/maven/README.md
@@ -1,0 +1,28 @@
+# devxp-ansible-collection-wsl.maven
+
+- [maven](https://maven.apache.org/)
+
+This role installs Apache Maven locally, allowing you to build and manage Java projects (including TeamCity DSL) with version consistency.
+Maven automates your build process and handles dependency management efficiently.
+
+## Usage
+
+Include the role in your playbook as shown below:
+
+```yaml
+- name: Install Apache Maven
+  hosts: localhost
+  collections:
+    - elhub.wsl
+  roles:
+    - role: maven
+```
+
+Alternatively, it can be imported as part of a playbook:
+
+```yaml
+- ansible.builtin.import_role:
+    name: elhub.wsl.maven
+  tags:
+    - maven
+```

--- a/roles/maven/meta/main.yml
+++ b/roles/maven/meta/main.yml
@@ -1,0 +1,14 @@
+---
+galaxy_info:
+  role_name: maven
+  namespace: elhub
+  author: elhub/devxp
+  description: See README
+  company: Elhub
+  license: MIT
+  min_ansible_version: "2.2"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - noble
+  galaxy_tags: []

--- a/roles/maven/tasks/main.yml
+++ b/roles/maven/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Check if maven is already installed with sdk
+  ansible.builtin.stat:
+    path: "{{ sdkman_dir }}/candidates/maven/current"
+  register: maven_installed
+
+- name: Install latest maven via sdk
+  ansible.builtin.shell: |
+    source "{{ sdkman_dir }}/bin/sdkman-init.sh"
+    sdk install maven 3.9.10
+  args:
+    executable: /bin/bash
+  register: sdk_install
+  when: not maven_installed.stat.exists
+  changed_when: true


### PR DESCRIPTION
Installing `maven` with `sdk` locally since `java` is already installed via this tool (see our setup playbook), and is it also easier to switch between different `maven` versions with `sdkman`

Alternative installation methods (`apt`, `yum`, `homebrew`) would create inconsistency in our toolchain management. But open to explore other approaches :D 

## 🔗 Issue ID(s): TDX-858

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ⚠️ **No tests could be run for this PR.**
* ✅ Documentation Updates: README
